### PR TITLE
Pyarray#index never returns if obj is in array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,8 @@ class Pyarray {
 
 	index(obj) {
 		const nativeIndex = this.obj.indexOf(obj);
-		if(nativeIndex === -1) throw new Error(`pyarray: ValueError: ${obj} is not in list`)
+		if(nativeIndex === -1) throw new Error(`pyarray: ValueError: ${obj} is not in list`);
+		return nativeIndex;
 	}
 
 	count(obj) {


### PR DESCRIPTION
Referencing https://docs.python.org/2/tutorial/datastructures.html#more-on-lists:

```python
list.index(x)
Return the index in the list of the first item whose value is x. It is an error if there is no such item.
```

`index` `throws` error if `obj` is not in the array but never returns list index otherwise, which causes `index` to returns `undefined` if no error was thrown.