### PR TITLE
Fixes #8 [TypeScript] Pyarray should be exported

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,6 @@ declare type PyArray<T> = PyArrayIndex<T> & Pyarray<T> & Array<T>;
 
 declare function pyarray<T>(list?: Array<T>): PyArray<T>;
 
-export { PyArray };
+export { Pyarray, PyArray };
 
 export default pyarray;


### PR DESCRIPTION
`Pyarray` is now `export`ed.
